### PR TITLE
Add implementation

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,0 +1,15 @@
+{
+	"all": true,
+	"include": [
+		"{dist/source,source}/**/*.{js,ts}"
+	],
+	"exclude": [
+		"{coverage,dist/test}/**",
+		"dist/**/*.d.ts",
+		"*.config.js"
+	],
+	"reporter": [
+		"html",
+		"lcov"
+	]
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+Translations: [Español](https://github.com/avajs/ava-docs/blob/master/es_ES/code-of-conduct.md), [Français](https://github.com/avajs/ava-docs/blob/master/fr_FR/code-of-conduct.md), [Italiano](https://github.com/avajs/ava-docs/blob/master/it_IT/code-of-conduct.md), [日本語](https://github.com/avajs/ava-docs/blob/master/ja_JP/code-of-conduct.md), [Português](https://github.com/avajs/ava-docs/blob/master/pt_BR/code-of-conduct.md), [Русский](https://github.com/avajs/ava-docs/blob/master/ru_RU/code-of-conduct.md), [简体中文](https://github.com/avajs/ava-docs/blob/master/zh_CN/code-of-conduct.md)
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at sindresorhus@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing to AVA
+
+✨ Thanks for contributing to AVA! ✨
+
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+
+This repository is a part of AVA. Start with reading AVA's [contributing guide](https://github.com/avajs/ava/blob/master/.github/CONTRIBUTING.md). Issue labels may be a little different in this repository but otherwise the same applies.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,15 @@
+---
+name: Bug Report
+about: If something isn't working the way you expect it to
+labels: needs triage
+---
+
+Please provide details about:
+
+* What you're trying to do
+* What happened
+* What you expected to happen
+
+Please share relevant sample code. Or better yet, provide a link to a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example).
+
+We'll also need your AVA configuration (in `package.json` or `ava.config.*` configuration files) and how you're invoking AVA. Share the installed AVA version (get it by running `npx ava --version`).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: AVA on Spectrum
+    url: https://spectrum.chat/ava
+    about: Ask questions and discuss in our Spectrum community
+  - name: Stack Overflow
+    url: https://stackoverflow.com/questions/tagged/ava
+    about: Tag your question on Stack Overflow

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,11 @@
+---
+name: Feature Request
+about: Suggestions for new or different behavior
+labels: question
+---
+
+Please provide details about:
+
+* What you're trying to do
+* Why you can't use this plugin for this
+* And maybe how you think AVA could handle this

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Install and test @ava/cooperate
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    paths-ignore:
+    - '*.md'
+jobs:
+  nodejs:
+    name: Node.js
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [^12.17.0, ^14.0.0]
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install --no-audit
+      - run: npm test
+      - uses: codecov/codecov-action@v1
+        with:
+          file: coverage/lcov.info
+          name: ${{ matrix.node-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+coverage
+dist
+node_modules

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# @ava/get-port
+
+Experimental AVA plugin which builds on [`get-port`](https://github.com/sindresorhus/get-port), but ensures the port is locked across all test files.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # @ava/get-port
 
-Experimental AVA plugin which builds on [`get-port`](https://github.com/sindresorhus/get-port), but ensures the port is locked across all test files.
+Experimental AVA plugin which works like [`get-port`](https://github.com/sindresorhus/get-port), but ensures the port is locked across all test files.

--- a/ava.config.js
+++ b/ava.config.js
@@ -1,0 +1,8 @@
+export default { // eslint-disable-line import/no-anonymous-default-export
+	files: ['!dist/**'],
+	typescript: {
+		rewritePaths: {
+			'test/': 'dist/test/'
+		}
+	}
+};

--- a/ava.config.js
+++ b/ava.config.js
@@ -1,5 +1,8 @@
 export default { // eslint-disable-line import/no-anonymous-default-export
 	files: ['!dist/**'],
+	nonSemVerExperiments: {
+		sharedWorkers: true
+	},
 	typescript: {
 		rewritePaths: {
 			'test/': 'dist/test/'

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
 		"typescript": "^4.0.2",
 		"xo": "^0.33.1"
 	},
+	"dependencies": {
+		"@ava/cooperate": "github:avajs/cooperate#reserve"
+	},
 	"peerDependencies": {
 		"ava": "*"
 	}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+	"name": "@ava/get-port",
+	"version": "0.0.0",
+	"description": "Cooperative get-port implementation",
+	"engines": {
+		"node": ">=12.17.0 <13 || >=14.0.0"
+	},
+	"files": [
+		"dist/source"
+	],
+	"main": "dist/source",
+	"types": "dist/source/index.d.ts",
+	"scripts": {
+		"build": "del-cli dist && tsc",
+		"prepare": "npm run -s build",
+		"test": "xo && tsd && c8 ava"
+	},
+	"keywords": [
+		"ava",
+		"lock",
+		"mutex",
+		"plugin",
+		"test"
+	],
+	"author": "Mark Wubben (https://novemberborn.net)",
+	"repository": "avajs/get-port",
+	"license": "MIT",
+	"devDependencies": {
+		"@ava/typescript": "^1.1.1",
+		"@sindresorhus/tsconfig": "^0.7.0",
+		"ava": "github:avajs/ava#shared-worker-plugins",
+		"c8": "^7.3.0",
+		"del-cli": "^3.0.1",
+		"tsd": "^0.13.1",
+		"typescript": "^4.0.2",
+		"xo": "^0.33.1"
+	},
+	"peerDependencies": {
+		"ava": "*"
+	}
+}

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
 		"@ava/typescript": "^1.1.1",
 		"@sindresorhus/tsconfig": "^0.7.0",
 		"ava": "^3.13.0",
-		"c8": "^7.3.0",
+		"c8": "^7.3.1",
 		"del-cli": "^3.0.1",
 		"tsd": "^0.13.1",
-		"typescript": "^4.0.2",
+		"typescript": "^4.0.3",
 		"xo": "^0.33.1"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 	"devDependencies": {
 		"@ava/typescript": "^1.1.1",
 		"@sindresorhus/tsconfig": "^0.7.0",
-		"ava": "github:avajs/ava#shared-worker-plugins",
+		"ava": "^3.13.0",
 		"c8": "^7.3.0",
 		"del-cli": "^3.0.1",
 		"tsd": "^0.13.1",
@@ -36,7 +36,7 @@
 		"xo": "^0.33.1"
 	},
 	"dependencies": {
-		"@ava/cooperate": "github:avajs/cooperate#reserve"
+		"@ava/cooperate": "^0.1.0"
 	},
 	"peerDependencies": {
 		"ava": "*"

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,0 +1,50 @@
+import crypto from 'crypto';
+import net from 'net';
+import {SharedContext} from '@ava/cooperate';
+
+const context = new SharedContext(__filename);
+
+// Reserve a range of 16 addresses at a random offset.
+const reserveRange = async (): Promise<number[]> => {
+	let from: number;
+	do {
+		from = crypto.randomBytes(2).readUInt16BE(0);
+	} while (from < 1024 || from > 65520);
+
+	const range = Array.from({length: 16}, (_, index) => from + index);
+	return context.reserve(...range);
+};
+
+// Listen on the port to make sure it's available.
+const confirmAvailable = async (port: number, options?: net.ListenOptions): Promise<boolean> => new Promise((resolve, reject) => {
+	const server = net.createServer();
+	server.unref();
+	server.on('error', (error: Error & { code: string }) => {
+		if (error.code === 'EADDRINUSE' || error.code === 'EACCESS') {
+			resolve(false);
+		} else {
+			reject(error);
+		}
+	});
+	server.listen({...options, port}, () => {
+		server.close(() => resolve(true));
+	});
+});
+
+let available: Promise<number[]> = reserveRange();
+export default async function getPort(options?: Omit<net.ListenOptions, 'port'>): Promise<number> { // eslint-disable-line @typescript-eslint/ban-types
+	const promise = available;
+	const range = await promise;
+	const port = range.shift();
+
+	if (available === promise && range.length === 0) {
+		// (Pro-actively) reserve a new range
+		available = reserveRange();
+	}
+
+	if (port === undefined || !(await confirmAvailable(port, options))) {
+		return getPort(options);
+	}
+
+	return port;
+}

--- a/test-d/types.ts
+++ b/test-d/types.ts
@@ -1,0 +1,4 @@
+import {expectError} from 'tsd';
+import getPort from '..';
+
+expectError(await getPort({port: 1024}));

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,0 +1,37 @@
+import net from 'net';
+import {promisify} from 'util';
+import test from 'ava';
+import getPort from '../source';
+
+test('gets up to 16 ports in a block', async t => {
+	const first = await getPort();
+	let count = 1;
+
+	let newBlock;
+	while (newBlock === undefined) {
+		const port = await getPort(); // eslint-disable-line no-await-in-loop
+		if (port > first && port - 16 <= first) {
+			count++;
+		} else {
+			newBlock = port;
+		}
+	}
+
+	t.true(count > 1);
+	t.true(count <= 16);
+
+	t.log({count, first, newBlock});
+});
+
+test('port can be bound', async t => {
+	const server = net.createServer();
+	t.teardown(() => server.close());
+
+	const port = await getPort();
+	await promisify(server.listen.bind(server))(port);
+	t.is((server.address() as any).port, port);
+});
+
+test('can get ports simultaneously', async t => {
+	await t.notThrowsAsync(Promise.all([getPort(), getPort()]));
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "@sindresorhus/tsconfig",
+	"compilerOptions": {
+		"outDir": "dist",
+		"target": "es2019", // Node.js 12
+		"lib": [
+			"es2019"
+		],
+		"esModuleInterop": true,
+		"sourceMap": true
+	},
+	"include": [
+		"source",
+		"test"
+	]
+}

--- a/xo.config.js
+++ b/xo.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+	rules: {
+		'@typescript-eslint/prefer-readonly-parameter-types': 'off',
+		'no-void': 'off'
+	},
+	overrides: [
+		{
+			files: '**/*.ts',
+			rules: {
+				'@typescript-eslint/no-floating-promises': ['error', {ignoreVoid: true}]
+			}
+		}
+	]
+};


### PR DESCRIPTION
Uses https://github.com/avajs/cooperate/pull/1, together with https://github.com/avajs/ava/pull/2478, to implement something like [`get-port`](https://github.com/sindresorhus/get-port) that ensures test files executing concurrently don't accidentally get the same port.