### PR TITLE
Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [^12.22, ^14.17, ^16.4, ^17]
+        node-version: [^14.19, ^16.15, ^18]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
       matrix:
         node-version: [^14.19, ^16.15, ^18]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install --no-audit
       - run: npm test
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           file: coverage/lcov.info
           name: ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
 	},
 	"peerDependencies": {
 		"ava": "*"
+	},
+	"volta": {
+		"node": "18.5.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
 	"repository": "avajs/get-port",
 	"license": "MIT",
 	"devDependencies": {
-		"@ava/typescript": "^3.0.0",
-		"@sindresorhus/tsconfig": "^2.0.0",
-		"@types/node": "^16.11.6",
-		"ava": "4.0.0-rc.1",
-		"c8": "^7.10.0",
+		"@ava/typescript": "^3.0.1",
+		"@sindresorhus/tsconfig": "^3.0.1",
+		"@types/node": "^18.0.3",
+		"ava": "^4.3.0",
+		"c8": "^7.11.3",
 		"del-cli": "^4.0.1",
-		"tsd": "^0.18.0",
-		"typescript": "^4.4.4",
-		"xo": "^0.46.4"
+		"tsd": "^0.22.0",
+		"typescript": "^4.7.4",
+		"xo": "^0.50.0"
 	},
 	"dependencies": {
 		"@ava/cooperate": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"description": "Cooperative get-port implementation",
 	"engines": {
-		"node": ">=12.22 <13 || >=14.17 <15 || >=16.4 <17 || >=17"
+		"node": ">=14.19 <15 || >=16.15 <17 || >=18"
 	},
 	"files": [
 		"dist/source"


### PR DESCRIPTION
- Require Node.js 14.19, 16.15 or 18
- Pin Node.js 18 using Volta
- Update GHA
- Update dev dependencies
